### PR TITLE
Allows setting content type header via middleware

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -67,6 +67,15 @@ Arguments:
       showVersion: true,
       logger: Logger,
       domdiff: this.options.domdiff,
+      middleware: [
+        function (req, res, next) {
+          if (/.*\.php$/.test(req.url)) {
+            res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          }
+
+          next();
+        }
+      ],
 
       // CLI watches all files in the folder by default 
       // this is different from Eleventy usage!

--- a/server.js
+++ b/server.js
@@ -371,19 +371,42 @@ class EleventyDevServer {
     return (content || "") + script;
   }
 
-  renderFile(filepath, res) {
-    let contents = fs.readFileSync(filepath);
-    let mimeType = mime.getType(filepath);
+  getFileContentType(filepath, res) {
+    let contentType = res.getHeader("Content-Type");
 
-    if (mimeType === "text/html") {
-      res.setHeader("Content-Type", `text/html; charset=${this.options.encoding}`);
-
-      // the string is important here, wrapResponse expects strings internally for HTML content (for now)
-      return res.end(contents.toString());
+    // Content-Type might be already set via middleware
+    if (contentType) {
+      return contentType;
     }
 
-    if (mimeType) {
-      res.setHeader("Content-Type", mimeType);
+    let mimeType = mime.getType(filepath);
+    if (!mimeType) {
+      return;
+    }
+
+    contentType = mimeType;
+
+    // We only want to append charset if the header is not already set
+    if (contentType === "text/html") {
+      contentType = `text/html; charset=${this.options.encoding}`;
+    }
+
+    return contentType;
+  }
+
+  renderFile(filepath, res) {
+    let contents = fs.readFileSync(filepath);
+    let contentType = this.getFileContentType(filepath, res);
+
+    if (!contentType) {
+      return res.end(contents);
+    }
+
+    res.setHeader("Content-Type", contentType);
+
+    if (contentType.startsWith("text/html")) {
+      // the string is important here, wrapResponse expects strings internally for HTML content (for now)
+      return res.end(contents.toString());
     }
 
     return res.end(contents);

--- a/test/stubs/index.php
+++ b/test/stubs/index.php
@@ -1,0 +1,1 @@
+SAMPLE PHP


### PR DESCRIPTION
Currently the "Content-Type" header is automatically set to the value returned by ``mime.getType``.  
If the "Content-Type" header was already set by a middleware then this header will be overwritten.  

Within this change the "Content-Type" header is only set if it is not already defined.
The ``getFileContentType`` method is added to split Content-Type detection from rendering logic.  
If the Content-Type can't be detected, then no header is sent.  

An example middleware which I use for a website which I migrated from PHP to 11ty:
```js
function (req, res, next) {
        if (/.*\.php$/.test(req.url)) {
          res.setHeader('Content-Type', 'text/html; charset=utf-8');
        }

        next();
}
```