### PR TITLE
Add sec-fetch-mode check

### DIFF
--- a/server.js
+++ b/server.js
@@ -466,7 +466,11 @@ class EleventyDevServer {
 
   async onRequestHandler (req, res) {
     res = wrapResponse(res, content => {
-      if(this.options.liveReload !== false) {
+
+      // check to see if this is a client fetch and not a navigation
+      let isXHR = req.headers["sec-fetch-mode"] && req.headers["sec-fetch-mode"] != "navigate";
+
+      if(this.options.liveReload !== false && !isXHR) {
         let scriptContents = this._getFileContents("./client/reload-client.js");
         let integrityHash = ssri.fromData(scriptContents);
 


### PR DESCRIPTION
I work on some small tools and sites (such as https://github.com/Chalkbeat/powertoys/tree/main/tarot) where it's useful to have live reload built into a static server. However, I often retrieve HTML fragments over fetch (either to add dynamic content, or when writing custom elements that have non-trivial shadow root templates), and the current eleventy-dev-server appends the live reload script tag to these because it doesn't distinguish between page navigation and PJAX-like requests. This change adds a check for the `Sec-Fetch-Mode` header, and if it is present, only augments the HTML content if the header contains the "navigate" value, meaning that it's being loaded by the browser page navigation and not by client-side code.