### PR TITLE
Add support for byte-range requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "minimist": "^1.2.8",
     "morphdom": "^2.7.0",
     "please-upgrade-node": "^3.2.0",
+    "send": "^0.18.0",
     "ssri": "^8.0.1",
     "ws": "^8.13.0"
   },

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const WebSocket = require("ws");
 const { WebSocketServer } = WebSocket;
 const mime = require("mime");
 const ssri = require("ssri");
+const send = require("send");
 const devip = require("dev-ip");
 const chokidar = require("chokidar");
 const { TemplatePath } = require("@11ty/eleventy-utils");
@@ -458,6 +459,11 @@ class EleventyDevServer {
       debug( req.url, match );
   
       if (match) {
+        // Content-Range request, probably Safari trying to stream video
+        if (req.headers.range)  {
+          return send(req, match.filepath).pipe(res);
+        }
+
         if (match.statusCode === 200 && match.filepath) {
           return this.renderFile(match.filepath, res);
         }


### PR DESCRIPTION
Eleventy Dev Server does not currently support byte-range requests, which causes locally served video files to fail on Safari and all iOS browsers.

This PR adds support for byte-range requests, so local video files load correctly from partial byte-range requests. This fixes [#51](https://github.com/11ty/eleventy-dev-server/issues/51).

Rather than trying to implement a new byte-range handler, I suggest  the using the [send](https://www.npmjs.com/package/send) library from [PillarJS](https://pillarjs.github.io). This project already relies on their [finalhandler](https://www.npmjs.com/package/finalhandler) library. These two libraries each log about 25M downloads per week.
 
I recognize, respect and appreciate the desire to keep 11ty's installations small. Send has 13 dependencies, 7 of which are already utilized and installed by eleventy-dev-server.

With `send`, byte-range requests can be implemented by simply adding a range-header check to `eleventyProjectMiddleware`:

```js
if (req.headers.range) {
  return send(req, match.filepath).pipe(res);
}
```

#### Tests

The `fetchHeadersForRequest` test helper function was slightly modified. It now accepts an `extras` argument, which can be used to add additional [http.request options](https://nodejs.org/docs/latest-v18.x/api/http.html#httprequesturl-options-callback). This allows the new tests to include a `range` header. The function's "Invalid status code" error-check was also modified to recognize success codes `200` and `206`.

Changes to the tests were checked and verified before adding range-requests to **server.js**, all tests passed.

Two tests specific to this change were added. The first validates byte-range headers are returned correctly, the second assures byte-range headers do not appear on normal requests. 

Also note that `options.portReassignmentRetryCount` was increased to prevent the test suite from running out of ports. 
