### PR TITLE
Bugfix for trailing slash redirects when using pathPrefix option.

### DIFF
--- a/server.js
+++ b/server.js
@@ -280,7 +280,7 @@ class EleventyDevServer {
     if (indexHtmlExists && !url.endsWith("/")) {
       return {
         statusCode: 301,
-        url: url + "/",
+        url: u.pathname + "/",
       };
     }
 
@@ -288,7 +288,7 @@ class EleventyDevServer {
     if (htmlExists && url.endsWith("/")) {
       return {
         statusCode: 301,
-        url: url.substring(0, url.length - 1),
+        url: u.pathname.substring(0, u.pathname.length - 1),
       };
     }
 


### PR DESCRIPTION
Redirects implemented in the dev server will add or remove a trailing slash to the path depending on the resource requested at `/{path}` and the existence of `/{path}/index.html` or `/{path}.html`.

These redirects do not account for use of the `pathPrefix` option and will result in a request to `/{prefix}/{path}` redirecting to `/{path}/` when `/{prefix}/{path}/index.html` exists.

Similarly, a request to `/{prefix}/index/` when `/{prefix}/index.html` exists will result in a redirect to `/index`.

The solution I've proposed is to re-use the original path when redirecting in these cases, which will retain the `pathPrefix` portion of the path.