### PR TITLE
Allow custom index filename

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ const DEFAULT_OPTIONS = {
   pathPrefix: "/",      // May be overridden by Eleventy, adds a virtual base directory to your project
   watch: [],            // Globs to pass to separate dev server chokidar for watching
   aliases: {},          // Aliasing feature
+  index: 'index.html',  // Allow custom index file name
 
   // Logger (fancier one is injected by Eleventy)
   logger: {
@@ -255,7 +256,7 @@ class EleventyDevServer {
       };
     }
 
-    let indexHtmlPath = this.getOutputDirFilePath(url, "index.html");
+    let indexHtmlPath = this.getOutputDirFilePath(url, this.options.index);
     let indexHtmlExists = fs.existsSync(indexHtmlPath);
 
     let htmlPath = this.getOutputDirFilePath(url, ".html");
@@ -722,7 +723,7 @@ class EleventyDevServer {
     urls.push(path);
 
     if(path.endsWith("/index.html")) {
-      urls.push(path.slice(0, -1 * "index.html".length));
+      urls.push(path.slice(0, -1 * this.options.index.length));
     } else if(path.endsWith(".html")) {
       urls.push(path.slice(0, -1 * ".html".length));
     }

--- a/test/stubs/custom-index.html
+++ b/test/stubs/custom-index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="description" content="">
+		<title></title>
+	</head>
+	<body>
+		<code>test/stubs/custom-index.html</code>
+	</body>
+</html>

--- a/test/testServer.js
+++ b/test/testServer.js
@@ -230,8 +230,8 @@ test("pathPrefix without leading or trailing slash", async (t) => {
   server.close();
 });
 
-test("index option: serve custom index when provided", async (t) => {
-  let server = new EleventyDevServer("test-server", "./test/stubs/", { index: 'custom-index.html' });
+test("indexFileName option: serve custom index when provided", async (t) => {
+  let server = new EleventyDevServer("test-server", "./test/stubs/", { indexFileName: 'custom-index.html' });
 
   t.deepEqual(server.mapUrlToFilePath("/"), {
     statusCode: 200,
@@ -247,8 +247,8 @@ test("index option: serve custom index when provided", async (t) => {
   server.close();
 });
 
-test("index option: return 404 when custom index file doesn't exist", async (t) => {
-  let server = new EleventyDevServer("test-server", "./test/stubs/", { index: 'does-not-exist.html' });
+test("indexFileName option: return 404 when custom index file doesn't exist", async (t) => {
+  let server = new EleventyDevServer("test-server", "./test/stubs/", { indexFileName: 'does-not-exist.html' });
 
   t.deepEqual(server.mapUrlToFilePath("/"), {
     statusCode: 404,

--- a/test/testServer.js
+++ b/test/testServer.js
@@ -229,3 +229,30 @@ test("pathPrefix without leading or trailing slash", async (t) => {
 
   server.close();
 });
+
+test("index option: serve custom index when provided", async (t) => {
+  let server = new EleventyDevServer("test-server", "./test/stubs/", { index: 'custom-index.html' });
+
+  t.deepEqual(server.mapUrlToFilePath("/"), {
+    statusCode: 200,
+    filepath: testNormalizeFilePath("test/stubs/custom-index.html"),
+  });
+
+
+  t.deepEqual(server.mapUrlToFilePath("/route1/"), {
+    statusCode: 200,
+    filepath: testNormalizeFilePath("test/stubs/route1/custom-index.html"),
+  });
+
+  server.close();
+});
+
+test("index option: return 404 when custom index file doesn't exist", async (t) => {
+  let server = new EleventyDevServer("test-server", "./test/stubs/", { index: 'does-not-exist.html' });
+
+  t.deepEqual(server.mapUrlToFilePath("/"), {
+    statusCode: 404,
+  });
+
+  server.close();
+});


### PR DESCRIPTION
This enables setting a custom filename to be used instead of index.html when requesting a directory. This matches the "index" option in the Express serve-static module: https://expressjs.com/en/resources/middleware/serve-static.html (However, I didn't implement the `false` or array options).

Let me know if this change looks good / if there's any documentation I need to update!