### PR TITLE
Support rebuild event from dev server

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,10 +42,10 @@ class EleventyDevServer {
   }
 
   constructor(name, dir, options = {}) {
-    debug("Creating new Dev Server instance.")
+    debug("Creating new Dev Server instance.");
     this.name = name;
     this.normalizeOptions(options);
-    
+
     this.fileCache = {};
     // Directory to serve
     if(!dir) {
@@ -85,10 +85,10 @@ class EleventyDevServer {
       // TODO if using Eleventy and `watch` option includes output folder (_site) this will trigger two update events!
       this._watcher = chokidar.watch(this.options.watch, {
         // TODO allow chokidar configuration extensions (or re-use the ones in Eleventy)
-  
+
         ignored: ["**/node_modules/**", ".git"],
         ignoreInitial: true,
-  
+
         // same values as Eleventy
         awaitWriteFinish: {
           stabilityThreshold: 150,
@@ -100,7 +100,7 @@ class EleventyDevServer {
         this.logger.log( `File changed: ${path} (skips build)` );
         this.reloadFiles([path]);
       });
-      
+
       this._watcher.on("add", (path) => {
         this.logger.log( `File added: ${path} (skips build)` );
         this.reloadFiles([path]);
@@ -456,19 +456,19 @@ class EleventyDevServer {
     if(!res._shouldForceEnd) {
       let match = this.mapUrlToFilePath(req.url);
       debug( req.url, match );
-  
+
       if (match) {
         if (match.statusCode === 200 && match.filepath) {
           return this.renderFile(match.filepath, res);
         }
-  
+
         // Redirects, usually for trailing slash to .html stuff
         if (match.url) {
           res.statusCode = match.statusCode;
           res.setHeader("Location", match.url);
           return res.end();
         }
-  
+
         let raw404Path = this.getOutputDirFilePath("404.html");
         if(match.statusCode === 404 && this.isOutputFilePathExists(raw404Path)) {
           res.statusCode = match.statusCode;


### PR DESCRIPTION
This feature adds the ability to define a rebuildUrl in the config. When eleventy-dev-server is running and a POST request is made to that URL, 11ty rebuilds the site.

Rationale: I'm working on a cool 11ty / Strapi project. In the cloud, when content is updated on Strapi, Strapi can send a webhook to whichever service is hosting 11ty, to rebuild the 11ty site. However this doesn't work for local development, as discussed at https://github.com/11ty/eleventy/issues/604, https://github.com/11ty/eleventy/issues/691 and elsewhere.

There have been suggested workarounds that generally involve the 11ty user writing an(other) HTTP server to accept the request and dumping a file somewhere to trigger a rebuild. But it is clunky and we already have an HTTP server. I reused existing EventBus functionality; really most of my time was spent reading and understanding the code.

I hope this is useful; it's my first 11ty contribution so feel free to let me know how it may be improved. :)

Corresponding 11ty PR: https://github.com/11ty/eleventy/pull/3085

Please review the commits separately, one is mere formatting and the other is the code change.