### PR TITLE
Fix CSS live reload behavior when some stylesheets have no URL

### DIFF
--- a/client/reload-client.js
+++ b/client/reload-client.js
@@ -176,9 +176,11 @@ class EleventyReload {
   async onreload({ subtype, files, build }) {
     if (subtype === "css") {
       for (let link of document.querySelectorAll(`link[rel="stylesheet"]`)) {
-        let url = new URL(link.href);
-        url.searchParams.set("_11ty", Date.now());
-        link.href = url.toString();
+        if (link.href) {
+          let url = new URL(link.href);
+          url.searchParams.set("_11ty", Date.now());
+          link.href = url.toString();
+        }
       }
       Util.log(`CSS updated without page reload.`);
     } else {


### PR DESCRIPTION
This PR fixes a bug where CSS live reloading will break if there are any stylesheets present which do not have a url associated with them by skipping modifying any stylesheets without URLs. 

### Steps to re-create the problem

1. Add a stylesheet to a project which doesn't have an actual URL. Browser extensions like [Dark Mode for Chrome](https://chromewebstore.google.com/detail/dark-mode/dmghijelimhndkbmpgbldicpogfkceaj?pli=1) may add stylesheets without URLs on the page. 
2. Make a change to a stylesheet during local development with eleventy. 
3. See an error message get logged in the browsers console:

> TypeError: Failed to construct 'URL': Invalid URL