### PR TITLE
Adds CORS Header to all responses

### DIFF
--- a/server.js
+++ b/server.js
@@ -435,6 +435,7 @@ class EleventyDevServer {
     }
 
     res.setHeader("Content-Type", contentType);
+    res.setHeader("Access-Control-Allow-Origin", '*');
 
     if (contentType.startsWith("text/html")) {
       // the string is important here, wrapResponse expects strings internally for HTML content (for now)


### PR DESCRIPTION
**Question 1**: Should there be default CORS header(s), and if so, what should it be?
**Question 2**: Instead of default CORS headers, should there be a hook (or other) for configurable response headers?

This PR adds the following header to all responses (untested).

```Access-Control-Allow-Origin: *```

Issue ref: https://github.com/11ty/eleventy-dev-server/issues/80