### PR TITLE
Makes shutdown process asynchronous and graceful 

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -81,7 +81,7 @@ Arguments:
 
   close() {
     if(this.server) {
-      this.server.close();
+      return this.server.close();
     }
   }
 }

--- a/cmd.js
+++ b/cmd.js
@@ -67,9 +67,9 @@ try {
       domDiff: argv.domdiff,
     });
 
-    process.on("SIGINT", () => {
-      cli.close();
-      process.exit();
+    process.on("SIGINT", async () => {
+      await cli.close();
+      process.exitCode = 0;
     });
   }
 } catch (e) {

--- a/server.js
+++ b/server.js
@@ -834,6 +834,8 @@ class EleventyDevServer {
       await this._watcher.close();
       delete this._watcher;
     }
+
+    delete this._isClosing;
   }
 
   sendError({ error }) {

--- a/test/testServer.js
+++ b/test/testServer.js
@@ -6,7 +6,7 @@ function testNormalizeFilePath(filepath) {
   return filepath.split("/").join(path.sep);
 }
 
-test("Url mappings for resource/index.html", t => {
+test("Url mappings for resource/index.html", async (t) => {
   let server = new EleventyDevServer("test-server", "./test/stubs/");
 
   t.deepEqual(server.mapUrlToFilePath("/route1/"), {
@@ -27,11 +27,11 @@ test("Url mappings for resource/index.html", t => {
     statusCode: 200,
     filepath: testNormalizeFilePath("test/stubs/route1/index.html")
   });
-
-  server.close();
+  
+  await server.close();  
 });
 
-test("Url mappings for resource.html", t => {
+test("Url mappings for resource.html", async (t) => {
   let server = new EleventyDevServer("test-server", "./test/stubs/");
 
   t.deepEqual(server.mapUrlToFilePath("/route2/"), {
@@ -53,10 +53,10 @@ test("Url mappings for resource.html", t => {
     filepath: testNormalizeFilePath("test/stubs/route2.html",)
   });
 
-  server.close();
+  await server.close();
 });
 
-test("Url mappings for resource.html and resource/index.html", t => {
+test("Url mappings for resource.html and resource/index.html", async (t) => {
   let server = new EleventyDevServer("test-server", "./test/stubs/");
 
   // Production mismatch warning: Netlify 301 redirects to /route3 here
@@ -80,10 +80,10 @@ test("Url mappings for resource.html and resource/index.html", t => {
     filepath: testNormalizeFilePath("test/stubs/route3.html",)
   });
 
-  server.close();
+  await server.close();
 });
 
-test("Url mappings for missing resource", t => {
+test("Url mappings for missing resource", async (t) => {
   let server = new EleventyDevServer("test-server", "./test/stubs/");
 
   // 404s
@@ -91,10 +91,10 @@ test("Url mappings for missing resource", t => {
     statusCode: 404
   });
 
-  server.close();
+  await server.close();
 });
 
-test("Url mapping for a filename with a space in it", t => {
+test("Url mapping for a filename with a space in it", async (t) => {
   let server = new EleventyDevServer("test-server", "./test/stubs/");
 
   t.deepEqual(server.mapUrlToFilePath("/route space.html"), {
@@ -102,7 +102,7 @@ test("Url mapping for a filename with a space in it", t => {
     filepath: testNormalizeFilePath("test/stubs/route space.html",)
   });
 
-  server.close();
+  await server.close();
 });
 
 test("matchPassthroughAlias", async (t) => {
@@ -131,6 +131,8 @@ test("matchPassthroughAlias", async (t) => {
   
   // Map entry exists, file exists
   t.is(server.matchPassthroughAlias("/elsewhere/index.css"), "./test/stubs/with-css/style.css");
+
+  await server.close();
 });
 
 
@@ -155,7 +157,7 @@ test("pathPrefix matching", async (t) => {
     url: '/pathprefix/',
   });
 
-  server.close();
+  await server.close();
 });
 
 test("pathPrefix without leading slash", async (t) => {
@@ -179,7 +181,7 @@ test("pathPrefix without leading slash", async (t) => {
     url: '/pathprefix/',
   });
 
-  server.close();
+  await server.close();
 });
 
 test("pathPrefix without trailing slash", async (t) => {
@@ -203,7 +205,7 @@ test("pathPrefix without trailing slash", async (t) => {
     url: '/pathprefix/',
   });
 
-  server.close();
+  await server.close();
 });
 
 test("pathPrefix without leading or trailing slash", async (t) => {
@@ -227,7 +229,7 @@ test("pathPrefix without leading or trailing slash", async (t) => {
     url: '/pathprefix/',
   });
 
-  server.close();
+  await server.close();
 });
 
 test("indexFileName option: serve custom index when provided", async (t) => {
@@ -244,7 +246,7 @@ test("indexFileName option: serve custom index when provided", async (t) => {
     filepath: testNormalizeFilePath("test/stubs/route1/custom-index.html"),
   });
 
-  server.close();
+  await server.close();
 });
 
 test("indexFileName option: return 404 when custom index file doesn't exist", async (t) => {
@@ -254,5 +256,5 @@ test("indexFileName option: return 404 when custom index file doesn't exist", as
     statusCode: 404,
   });
 
-  server.close();
+  await server.close();
 });

--- a/test/testServerRequests.js
+++ b/test/testServerRequests.js
@@ -75,7 +75,7 @@ async function fetchHeadersForRequest(t, server, path, extras) {
   })
 }
 
-test("Standard request", async t => {
+test("Standard request", async (t) => {
   let server = new EleventyDevServer("test-server", "./test/stubs/", getOptions());
   server.serve(8100);
 
@@ -83,7 +83,7 @@ test("Standard request", async t => {
   t.true(data.includes("<script "));
   t.true(data.startsWith("SAMPLE"));
 
-  server.close();
+  await server.close();  
 });
 
 test("One sync middleware", async t => {
@@ -101,7 +101,7 @@ test("One sync middleware", async t => {
   t.true(data.includes("<script "));
   t.true(data.startsWith("SAMPLE"));
 
-  server.close();
+  await server.close();
 });
 
 test("Two sync middleware", async t => {
@@ -121,7 +121,7 @@ test("Two sync middleware", async t => {
   t.true(data.includes("<script "));
   t.true(data.startsWith("SAMPLE"));
 
-  server.close();
+  await server.close();
 });
 
 test("One async middleware", async t => {
@@ -138,7 +138,7 @@ test("One async middleware", async t => {
   t.true(data.includes("<script "));
   t.true(data.startsWith("SAMPLE"));
 
-  server.close();
+  await server.close();
 });
 
 test("Two async middleware", async t => {
@@ -158,7 +158,7 @@ test("Two async middleware", async t => {
   t.true(data.includes("<script "));
   t.true(data.startsWith("SAMPLE"));
 
-  server.close();
+  await server.close();
 });
 
 test("Async middleware that writes", async t => {
@@ -186,7 +186,7 @@ test("Async middleware that writes", async t => {
   t.true(data.includes("<script "));
   t.true(data.startsWith("Injected"));
 
-  server.close();
+  await server.close();
 });
 
 test("Second async middleware that writes", async t => {
@@ -223,7 +223,7 @@ test("Second async middleware that writes", async t => {
   t.true(data.includes("<script "));
   t.true(data.startsWith("Injected"));
 
-  server.close();
+  await server.close();
 });
 
 
@@ -250,7 +250,7 @@ test("Second middleware that consumes first middleware response body, issue #29"
   t.true(data.includes("<script "));
   t.true(data.startsWith("First Second "));
 
-  server.close();
+  await server.close();
 });
 
 test("Two middlewares, end() in the first, skip the second", async t => {
@@ -276,7 +276,7 @@ test("Two middlewares, end() in the first, skip the second", async t => {
   t.true(data.startsWith("First "));
   t.true(!data.startsWith("First Second "));
 
-  server.close();
+  await server.close();
 });
 
 test("Fun unicode paths", async t => {
@@ -287,7 +287,7 @@ test("Fun unicode paths", async t => {
   t.true(data.includes("<script "));
   t.true(data.startsWith("This is a test"));
 
-  server.close();
+  await server.close();
 });
 
 test("Content-Type header via middleware", async t => {
@@ -307,7 +307,7 @@ test("Content-Type header via middleware", async t => {
   let data = await fetchHeadersForRequest(t, server, encodeURI(`/index.php`));
   t.true(data['content-type'] === 'text/html; charset=utf-8');
 
-  server.close();
+  await server.close();
 });
 
 test("Content-Range request", async (t) => {
@@ -325,7 +325,7 @@ test("Content-Range request", async (t) => {
   t.true("content-range" in data);
   t.true(data["content-range"].startsWith("bytes 0-48/"));
 
-  server.close();
+  await server.close();
 });
 
 test("Standard request does not include range headers", async (t) => {
@@ -340,5 +340,5 @@ test("Standard request does not include range headers", async (t) => {
   t.false("accept-ranges" in data);
   t.false("content-range" in data);
 
-  server.close();
+  await server.close();
 });


### PR DESCRIPTION
As proposed in #84:

- `EleventyDevServer.close()` is now async and awaits all underlying `close()` methods.
- It also prevents multiple invocations (due to multiple SIGINTs).
- It also closes any existing WebSocket connections, since this doesn't happen automatically (see [WS docs](https://github.com/websockets/ws/blob/bfe1b2a623eb881a107ccf9a95042e8b22933687/doc/ws.md#serverclosecallback)).
-  `Cli`and `Cmd` handle the now async `close()`.
- All tests also handle async close().