### PR TITLE
Add option for setting default response headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ const DEFAULT_OPTIONS = {
   aliases: {},          // Aliasing feature
   indexFileName: "index.html", // Allow custom index file name
   useCache: false,      // Use a cache for file contents
+  headers: {},          // Set default response headers
   messageOnStart: ({ hosts, startupTime, version, options }) => {
     let hostsStr = " started";
     if(Array.isArray(hosts) && hosts.length > 0) {
@@ -430,6 +431,10 @@ class EleventyDevServer {
   renderFile(filepath, res) {
     let contents = fs.readFileSync(filepath);
     let contentType = this.getFileContentType(filepath, res);
+
+    for(const [key, value] of Object.entries(this.options.headers)){
+      res.setHeader(key, value);
+    }
 
     if (!contentType) {
       return res.end(contents);

--- a/test/testServerRequests.js
+++ b/test/testServerRequests.js
@@ -342,3 +342,41 @@ test("Standard request does not include range headers", async (t) => {
 
   await server.close();
 });
+
+test("Setting default response headers", async (t) => {
+  let server = new EleventyDevServer(
+    "test-server",
+    "./test/stubs/",
+    getOptions({
+      headers: {
+        "access-control-allow-origin": "*",
+        "x-foo": "y-bar",
+      }
+    })
+  );
+  server.serve(8100);
+
+  let data = await fetchHeadersForRequest(t, server, "/index.html");
+  t.true(data["access-control-allow-origin"] === "*");
+  t.true(data["x-foo"] === "y-bar");
+
+  await server.close();
+});
+
+test("Default response headers cannot overwrite content-type", async (t) => {
+  let server = new EleventyDevServer(
+    "test-server",
+    "./test/stubs/",
+    getOptions({
+      headers: {
+        "Content-Type": "text/plain",
+      }
+    })
+  );
+  server.serve(8100);
+
+  let data = await fetchHeadersForRequest(t, server, "/index.html");
+  t.false(data["Content-Type"] === "text/plain");
+
+  await server.close();
+});


### PR DESCRIPTION
This is a PR that resolves https://github.com/11ty/eleventy-dev-server/issues/80.

This adds a `headers` option, which may be set to an object of key-value pairs that are subsequently used as default headers.

For example, to add a `Access-Control-Allow-Origin` header, on might do:
```
export default function(eleventyConfig){
  // …
  eleventyConfig.setServerOptions({
    headers: {
      'Access-Control-Allow-Origin': '*'
    }
  });
  // …
};
```
By default, no headers are set as defaults.

The `Content-Type` header should probably not be overwritten, so these defaults are set before the `Content-Type` header is added.