### PR TITLE
fix: bumps send to version 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "minimist": "^1.2.8",
     "morphdom": "^2.7.4",
     "please-upgrade-node": "^3.2.0",
-    "send": "^0.18.0",
+    "send": "^1.1.0",
     "ssri": "^11.0.0",
     "urlpattern-polyfill": "^10.0.0",
     "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "minimist": "^1.2.8",
     "morphdom": "^2.7.4",
     "please-upgrade-node": "^3.2.0",
-    "send": "^1.1.0",
+    "send": "^0.19.0",
     "ssri": "^11.0.0",
     "urlpattern-polyfill": "^10.0.0",
     "ws": "^8.18.0"


### PR DESCRIPTION
This will bump send to version 1.1.0 https://github.com/pillarjs/send/releases/tag/1.1.0 and close https://github.com/11ty/eleventy-dev-server/issues/91