### PR TITLE
Update MIME type handling for the local dev server.

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ const DEFAULT_OPTIONS = {
   messageOnStart: ({ hosts, startupTime, version, options }) => {
     let hostsStr = " started";
     if(Array.isArray(hosts) && hosts.length > 0) {
-      // TODO what happens when the cert doesn’t cover non-localhost hosts?
+      // TODO what happens when the cert doesn't cover non-localhost hosts?
       hostsStr = ` at ${hosts.join(" or ")}`;
     }
 
@@ -395,7 +395,7 @@ class EleventyDevServer {
 
     let searchParamsStr = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
 
-    // This isn’t super necessary because it’s a local file, but it’s included anyway
+    // This isn't super necessary because it's a local file, but it's included anyway
     let script = `<script type="module" integrity="${integrityHash}"${inlineContents ? `>${scriptContents}` : ` src="/${this.options.injectedScriptsFolder}/reload-client.js${searchParamsStr}">`}</script>`;
 
     if (content.includes("</head>")) {
@@ -415,7 +415,7 @@ class EleventyDevServer {
       return content.replace("</title>", `</title>${script}`);
     }
 
-    // If you’ve reached this section, your HTML is invalid!
+    // If you've reached this section, your HTML is invalid!
     // We want to be super forgiving here, because folks might be in-progress editing the document!
     if (content.includes("</body>")) {
       return content.replace("</body>", `${script}</body>`);
@@ -439,16 +439,65 @@ class EleventyDevServer {
       return contentType;
     }
 
-    let mimeType = mime.getType(filepath);
-    if (!mimeType) {
+    // Common web file extensions and their content types
+    const commonTypes = {
+
+      '.css': 'text/css',
+      '.js': 'application/javascript',
+      '.json': 'application/json',
+      '.txt': 'text/plain',
+      '.ico': 'image/x-icon',
+      '.svg': 'image/svg+xml',
+      '.woff': 'font/woff',
+      '.woff2': 'font/woff2',
+      '.ttf': 'font/ttf',
+      '.eot': 'application/vnd.ms-fontobject',
+      '.otf': 'font/otf',
+      '.webp': 'image/webp',
+      '.webm': 'video/webm',
+      '.mp4': 'video/mp4',
+      '.m4v': 'video/mp4',
+      '.mp3': 'audio/mpeg',
+      '.wav': 'audio/wav',
+      '.pdf': 'application/pdf',
+      '.xml': 'application/xml',
+      '.zip': 'application/zip',
+      '.gz': 'application/gzip',
+      '.br': 'application/x-brotli',
+      '.tar': 'application/x-tar',
+      '.md': 'text/markdown',
+      '.yaml': 'application/yaml',
+      '.yml': 'application/yaml'
+    };
+
+    const ext = path.extname(filepath).toLowerCase();
+    
+    // First check our common types
+    if (commonTypes[ext]) {
+      contentType = commonTypes[ext];
+    } else {
+      // Fallback to mime package for other types
+      contentType = mime.getType(filepath);
+    }
+
+    if (!contentType) {
       return;
     }
 
-    contentType = mimeType;
+    // Add charset for text-based content types
+    const textTypes = [
+      'text/',
+      'text/html',
+      'application/javascript',
+      'application/json',
+      'application/xml',
+      'application/yaml',
+      'application/x-www-form-urlencoded'
+    ];
 
-    // We only want to append charset if the header is not already set
-    if (contentType === "text/html") {
-      contentType = `text/html; charset=${this.options.encoding}`;
+    // Check if the content type matches any text-based MIME types to determine if charset should be added
+    if (textTypes.some(type => contentType.startsWith(type))) {
+      contentType = `${contentType}; charset=${this.options.encoding}`;
     }
 
     return contentType;
@@ -871,7 +920,7 @@ class EleventyDevServer {
         resolve();
       });
 
-      // Note: this method won’t exist for updateServer
+      // Note: this method won't exist for updateServer
       if("closeAllConnections" in server) {
         // Node 18.2+
         server.closeAllConnections();
@@ -1003,7 +1052,7 @@ class EleventyDevServer {
       build.templates = build.templates
         .filter(entry => {
           if(!this.options.domDiff) {
-            // Don’t include any files if the dom diffing option is disabled
+            // Don't include any files if the dom diffing option is disabled
             return false;
           }
 


### PR DESCRIPTION
Updated the dev server's MIME type handling to support a comprehensive set of file types. The server now handles: text-based files (`.html`,`.css`, `.js`, `.json`, `.txt`, `.md`, `.xml`, `.yaml`, `.yml`), images (`.ico`, `.svg`, `.webp`), fonts (`.woff`, `.woff2`, `.ttf`, `.eot`, `.otf`), media (`.webm`, `.mp4`, `.m4v`, `.mp3`, `.wav`), documents (`.pdf`), and compressed archives (`.zip`, `.gz`, `.br`, `.tar`). Each file type is served with its appropriate MIME type and charset encoding for text-based content.