### PR TITLE
Avoid use of reserved word `interface`

### DIFF
--- a/server/ipAddress.js
+++ b/server/ipAddress.js
@@ -3,7 +3,7 @@ const os = require("node:os");
 const INTERFACE_FAMILIES = ["IPv4"];
 
 module.exports = function() {
-    return Object.values(os.networkInterfaces()).flat().filter(interface => {
-        return interface.internal === false && INTERFACE_FAMILIES.includes(interface.family);
-    }).map(interface => interface.address);
+    return Object.values(os.networkInterfaces()).flat().filter(({family, internal}) => {
+        return internal === false && INTERFACE_FAMILIES.includes(family);
+    }).map(({ address }) => address);
 };


### PR DESCRIPTION
I encountered an interesting-to-me issue while experimenting with Eleventy and Cloudflare Pages Functions (see [this toot](https://indieweb.social/@jgarber/114592085115262074)).

In strict mode, `interface` is a reserved word. Or, at least _will_ be a reserved word [in the future](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#future_reserved_words). Something within Cloudflare's stack (esbuild, I suspect) is running in strict mode and threw this error:

```
  ✘ [ERROR] "interface" is a reserved word and cannot be used
  with the "esm" output format due to strict mode
```

Hunh. Well, TIL as they say.

This change uses destructuring to avoid use of `interface` in the `filter` and `map` callbacks. If destructuring isn't preferred, an alternative implementation could change the use of `interface` to `iface` or similar.

Thanks for considering this change!