### PR TITLE
Add missing dependency `please-upgrade-node`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "mime": "^4.1.0",
         "minimist": "^1.2.8",
         "morphdom": "^2.7.7",
+        "please-upgrade-node": "^3.2.0",
         "send": "^1.2.0",
         "ssri": "^13.0.0",
         "urlpattern-polyfill": "^10.1.0",
@@ -1830,6 +1831,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver-compare": "^1.0.0"
+      }
+    },
     "node_modules/plur": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
@@ -1984,6 +1994,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mime": "^4.1.0",
     "minimist": "^1.2.8",
     "morphdom": "^2.7.7",
+    "please-upgrade-node": "^3.2.0",
     "send": "^1.2.0",
     "ssri": "^13.0.0",
     "urlpattern-polyfill": "^10.1.0",


### PR DESCRIPTION
cmd.js requires the package `please-upgrade-node` but it's missing from package.json and package-lock.json

```
eleventy-dev-server

node:internal/modules/cjs/loader:1478
  throw err;
  ^

Error: Cannot find module 'please-upgrade-node'
Require stack:
- /website/node_modules/.pnpm/@11ty+eleventy-dev-server@3.0.0-alpha.6/node_modules/@11ty/eleventy-dev-server/cmd.cjs
    at Module._resolveFilename (node:internal/modules/cjs/loader:1475:15)
    at wrapResolveFilename (node:internal/modules/cjs/loader:1048:27)
    at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1072:10)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1093:12)
    at Module._load (node:internal/modules/cjs/loader:1261:25)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.require (node:internal/modules/cjs/loader:1575:12)
    at require (node:internal/modules/helpers:191:16)
    at Object.<anonymous> (/website/node_modules/.pnpm/@11ty+eleventy-dev-server@3.0.0-alpha.6/node_modules/@11ty/eleventy-dev-server/cmd.cjs:6:1)
    at Module._compile (node:internal/modules/cjs/loader:1831:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/website/node_modules/.pnpm/@11ty+eleventy-dev-server@3.0.0-alpha.6/node_modules/@11ty/eleventy-dev-server/cmd.cjs'
  ]
}
```

This PR adds `please-upgrade-node` as a dependency.

---

Node.js v25.8.0
eleventy-dev-server@3.0.0-alpha.6