### PR TITLE
Remove ssri dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "minimist": "^1.2.8",
         "morphdom": "^2.7.8",
         "send": "^1.2.1",
-        "ssri": "^13.0.1",
         "urlpattern-polyfill": "^10.1.0",
         "ws": "^8.20.0"
       },
@@ -1609,6 +1608,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2113,18 +2113,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/ssri": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "minimist": "^1.2.8",
     "morphdom": "^2.7.8",
     "send": "^1.2.1",
-    "ssri": "^13.0.1",
     "urlpattern-polyfill": "^10.1.0",
     "ws": "^8.20.0"
   },

--- a/server.js
+++ b/server.js
@@ -4,12 +4,12 @@ import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { createSecureServer } from "node:http2";
 import { createServer } from "node:http";
+import crypto from "node:crypto";
 
 import "urlpattern-polyfill";
 import finalhandler from "finalhandler";
 import WebSocket, { WebSocketServer } from "ws";
 import mime from "mime";
-import ssri from "ssri";
 import send from "send";
 import chokidar from "chokidar";
 import { TemplatePath, isPlainObject } from "@11ty/eleventy-utils";
@@ -421,7 +421,10 @@ export default class EleventyDevServer {
     return contents;
   }
 
-  // Used for the reload client only
+  /**
+   * Used for the reload client only
+   * @returns {String}
+   */
   #getFileContents(localpath, rootDir) {
     let filepath;
     let searchLocations = [];
@@ -449,7 +452,7 @@ export default class EleventyDevServer {
       scriptContents = this.#getFileContents("./client/reload-client.js");
     }
     if(!integrityHash) {
-      integrityHash = ssri.fromData(scriptContents);
+      integrityHash = this.#sri(scriptContents);
     }
 
     let searchParams = new URLSearchParams();
@@ -638,6 +641,13 @@ export default class EleventyDevServer {
     next();
   }
 
+  /**
+   * @param {String} data
+   */
+  #sri(data) {
+    return `sha512-${crypto.createHash("sha512").update(data).digest("base64")}`
+  }
+
   // This runs at the end of the middleware chain
   eleventyProjectMiddleware(req, res) {
     // Known issue with `finalhandler` and HTTP/2:
@@ -713,7 +723,7 @@ export default class EleventyDevServer {
 
       if(this.options.liveReload !== false && !isXHR) {
         let scriptContents = this.#getFileContents("./client/reload-client.js");
-        let integrityHash = ssri.fromData(scriptContents);
+        let integrityHash = this.#sri(scriptContents);
 
         // Bare (not-custom) finalhandler error pages have a Content-Security-Policy `default-src 'none'` that
         // prevents the client script from executing, so we override it


### PR DESCRIPTION
This removes the dependency on `ssri`, which generates sub-resource integrity identifiers. The way that this module was using it was a one-liner.

We still get `minipass` as a transitive dependency out of `devDependencies` but this removes minipass from dependencies, which is a nice 358.19kb win.

Quick test to confirm correctness (I wrote this just based on reading through ssri):

```js
import ssri from "ssri";
import crypto from "node:crypto";

const string = "hello world";

function sri(str) {
  return `sha512-${crypto.createHash("sha512").update(str).digest("base64")}`;
}

console.log(String(ssri.fromData(string)));
console.log(String(sri(string)));
```